### PR TITLE
Honor specified scale, Fix #4

### DIFF
--- a/lib/BcMathNumber.php
+++ b/lib/BcMathNumber.php
@@ -228,7 +228,7 @@ class BcMathNumber
         $left = $this->getValue();
         $right = $num instanceof self ? $num->getValue() : self::filterNum($num);
         $mod = $mod instanceof self ? $num->getValue() : self::filterNum($mod);
-        $scale = (int) ($scale ?: self::$defaultScale);
+        $scale = (int) (null === $scale ? self::$defaultScale : $scale);
 
         $args = array($left, $right, $scale);
         if ($operation == self::OPERATION_POWMOD) {


### PR DESCRIPTION
Issue: Specified scale of 0 resulting in use of the declared default scale.
Resolution: use default scale only when specified scale is null.
This closes #4